### PR TITLE
Call `arrange()` after `group_by() + summarize()`

### DIFF
--- a/R/reparam.R
+++ b/R/reparam.R
@@ -162,7 +162,8 @@ transform.df.parms = function(parms.df, out.format = c('b','beta','eta'), includ
     mutate(rn = row_number()) %>%
     group_by(.data$item_id) %>% 
     summarize(first = as.integer(min(.data$rn)), last = as.integer(max(.data$rn))) %>%
-    ungroup()
+    ungroup() %>%
+    arrange(.data$item_id)
   
   args = list(first = fl$first, last = fl$last, parms.df = parms.df, 
               out.zero = include.zero, in.zero = in.zero)


### PR DESCRIPTION
Hi there, we ran revdeps for dplyr and your package appeared in our checks.

We have updated `arrange()` to now have an explicit `.locale` argument that defaults to American English. It previously respected the system locale, but this is more performant and reproducible across R sessions.

You currently rely on the resulting ordering of `group_by(df, x) %>% summarize()` matching the ordering you'd get back from `arrange(df, x)`. Instead, we suggest explicitly calling `arrange()` after calling `summarize()` if you rely on that ordering, as it will no longer match `arrange()` automatically in the next version of dplyr.

If you install this PR, you will see that one of your tests fails because of this assumption. https://github.com/tidyverse/dplyr/pull/6263

Luckily, the fix here is simple and work with both dev and CRAN dplyr! If you could merge this PR and then go ahead and send a release to CRAN, then we would greatly appreciate it. It will make releasing the next version of dplyr easier for us.

Thanks!